### PR TITLE
Google nocaptcha recaptcha

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ django-filer==1.2.5
 django-haystack==2.5.0
 django-libsass==0.7
 django-localflavor==1.3
+django-nocaptcha-recaptcha==0.0.19
 django-parler==1.6.5
 django-polymorphic==0.8.1
 django-redis==4.5.0

--- a/rlp/accounts/forms.py
+++ b/rlp/accounts/forms.py
@@ -7,6 +7,8 @@ from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 from django.utils.translation import ugettext_lazy as _
 
+from nocaptcha_recaptcha.fields import NoReCaptchaField
+
 from .models import User, Institution
 from rlp.core.email import send_transactional_mail
 from rlp.projects.models import Project, Role, ProjectMembership
@@ -110,6 +112,7 @@ class RegistrationForm(UserCreationForm):
     project = forms.ModelChoiceField(queryset=Project.objects.all())
     role = forms.ModelChoiceField(help_text="Leave blank if not applicable",
                                   queryset=Role.objects.exclude(contact=True), required=False)
+    captcha = NoReCaptchaField()
 
     class Meta:
         model = User

--- a/rlp/accounts/templates/registration/register.html
+++ b/rlp/accounts/templates/registration/register.html
@@ -2,6 +2,11 @@
 
 {% load cms_tags %}
 
+{% block js-header %}{{ block.super }}
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+{% endblock js-header%}
+
+
 {% block page_title %}Register{% endblock page_title %}
 
 {% block title %}Register{% endblock title %}

--- a/rlp/settings_base.py
+++ b/rlp/settings_base.py
@@ -96,6 +96,7 @@ INSTALLED_APPS = (
     'parler',
     'taggit',
     'taggit_autosuggest',
+    'nocaptcha_recaptcha',
     'rlp.bibliography.apps.BibliographyConfig',
     'rlp.bookmarks.apps.BookmarksConfig',
     'rlp.core.apps.CoreConfig',


### PR DESCRIPTION
Got this working locally using the same method that we used for the Form Wizard in the capc site: overriding the render_done method of the SessionWizardView to pull out the captcha from the form after the initial validation so it doesn't get submitted twice when the form wizard revalidates.

You'll need to set the API keys in production as follows:

Required settings:
NORECAPTCHA_SITE_KEY  (string) = the Google provided site_key
NORECAPTCHA_SECRET_KEY (string) = the Google provided secret_key